### PR TITLE
fix: support different CC/CXX compilers

### DIFF
--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -361,12 +361,7 @@ class NativeBundle {
         eLinuxDir.path,
       ],
       workingDirectory: outputDir.path,
-      environment: (targetToolchain == null)
-          ? <String, String>{'CC': 'clang', 'CXX': 'clang++'}
-          : <String, String>{
-              'CC': '$targetToolchain/bin/clang',
-              'CXX': '$targetToolchain/bin/clang++'
-            },
+      environment: _buildCMakeEnvironment(targetToolchain),
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake:\n$result');
@@ -406,6 +401,17 @@ class NativeBundle {
       );
     }
   }
+}
+
+Map<String, String> _buildCMakeEnvironment(String? targetToolchain) {
+  final String? ccEnv = Platform.environment['CC'];
+  final String? cxxEnv = Platform.environment['CXX'];
+
+  final String cc = ccEnv ?? (targetToolchain != null ? '$targetToolchain/bin/clang' : 'clang');
+  final String cxx =
+      cxxEnv ?? (targetToolchain != null ? '$targetToolchain/bin/clang++' : 'clang++');
+
+  return <String, String>{'CC': cc, 'CXX': cxx};
 }
 
 String _getCurrentHostPlatformArchName() {


### PR DESCRIPTION
This commit addresses the issue where certain operating systems (e.g., NixOS) were unable to complete cross-platform compilation. The current implementation assumes that all clang and clang++ invocations are done using specific commands. However, in reality, the invocation of these compilers can vary. For example, on NixOS, the compiler commands are actually: `aarch64-unknown-linux-gnu-clang` and
`aarch64-unknown-linux-gnu-clang++`.

To resolve this, we should respect the original environment variable settings and allow users to determine the binary names provided by their distribution. This adjustment improves our support for different operating systems and compilation environments, enhancing the cross-platform compatibility of the project.