### PR TITLE
Wire native-asset build hooks into the eLinux bundle

### DIFF
--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -22,6 +22,7 @@ import 'package:flutter_tools/src/build_system/targets/icon_tree_shaker.dart';
 import 'package:flutter_tools/src/build_system/targets/native_assets.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/cmake.dart';
+import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/native_assets/dart_hook_result.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -56,7 +57,9 @@ abstract class ELinuxAssetBundle extends Target {
 
   @override
   List<Target> get dependencies => const <Target>[
+        DartBuildForNative(),
         KernelSnapshot(),
+        InstallCodeAssets(),
       ];
 
   @override
@@ -94,6 +97,11 @@ abstract class ELinuxAssetBundle extends Target {
       targetPlatform: tp,
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
+      additionalContent: <String, DevFSContent>{
+        'NativeAssetsManifest.json': DevFSFileContent(
+          environment.buildDir.childFile('native_assets.json'),
+        ),
+      },
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,
@@ -403,6 +411,16 @@ class NativeBundle {
         environment.outputDir.childDirectory('flutter_assets'),
         flutterAssetsDir,
       );
+    }
+
+    // Copy native code assets declared by build hooks (e.g. dynamically loaded
+    // shared libraries from `@Native` FFI bindings) into the bundle's lib
+    // directory. The list comes from `DartBuildForNative`, which runs
+    // transitively as a dependency of [ELinuxAssetBundle].
+    final DartHooksResult dartHookResult = await DartBuild.loadHookResult(environment);
+    for (final Uri assetUri in dartHookResult.filesToBeBundled) {
+      final File sourceFile = environment.fileSystem.file(assetUri);
+      sourceFile.copySync(outputBundleLibDir.childFile(sourceFile.basename).path);
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds support for Dart native-asset build hooks (e.g. `@Native` FFI shared
libraries declared in `hook/build.dart`) by following the upstream pattern
from [`packages/flutter_tools/lib/src/build_system/targets/linux.dart`](https://github.com/flutter/flutter/blob/main/packages/flutter_tools/lib/src/build_system/targets/linux.dart)
and [`.../android.dart`](https://github.com/flutter/flutter/blob/main/packages/flutter_tools/lib/src/build_system/targets/android.dart#L74):

- `ELinuxAssetBundle` now depends on `DartBuildForNative()` and `InstallCodeAssets()` alongside `KernelSnapshot()` — matching upstream's dependency list so hooks run and code assets are installed before bundling.
- `NativeAssetsManifest.json` is now emitted through `copyAssets`'s `additionalContent` parameter (same pattern as upstream `linux.dart:139-144` and `android.dart:82-87`). This routes it through the DevFS pipeline and includes it in `flutter_assets.d`, so incremental rebuilds invalidate correctly when `native_assets.json` changes.
- After `cmake --install`, `DartHooksResult.filesToBeBundled` is copied into the bundle's `lib/` directory so dynamically-loaded shared libraries ship with the final app.

## Relation to #8

This is a rework of #8. The original proposed the same feature but copied `NativeAssetsManifest.json` directly to the final bundle as a post-cmake step (bypassing the depfile) and omitted `DartBuildForNative()` from the dependency list. See review on #8 for the full discussion. Closes #8.

## Test plan

- [ ] Build a sample eLinux app whose `hook/build.dart` produces a code asset and verify `NativeAssetsManifest.json` lands in `<bundle>/data/flutter_assets/`.
- [ ] Verify the produced `.so` lands in `<bundle>/lib/`.
- [ ] Confirm the app resolves `@Native` symbols at runtime.
- [ ] Confirm an existing app with no hooks still builds (empty `filesToBeBundled`, empty manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)